### PR TITLE
avoid direct dependency on colcon-bash

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ install:
   # install_requires
   - pip install -U argcomplete
   - pip install -U git+https://github.com/colcon/colcon-core
-  - pip install -U git+https://github.com/colcon/colcon-bash
   - pip install -U git+https://github.com/colcon/colcon-metadata
   # tests_require
   - pip install -U flake8-blind-except flake8-builtins flake8-class-newline flake8-comprehensions flake8-deprecated flake8-docstrings flake8-quotes pep8-naming pyenchant pylint pytest pytest-cov

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,6 @@ keywords = colcon
 [options]
 install_requires =
   argcomplete
-  colcon-bash
   colcon-core
   colcon-metadata
 packages = find:


### PR DESCRIPTION
When installing this package not all potentially supported shells should need to be installed. The user should be able to install only the once desired.