### PR TITLE
call Python 3 version of the argcomplete function when available

### DIFF
--- a/completion/colcon-argcomplete.bash
+++ b/completion/colcon-argcomplete.bash
@@ -1,1 +1,5 @@
-eval "$(register-python-argcomplete colcon)"
+if type register-python-argcomplete3 > /dev/null 2>&1; then
+  eval "$(register-python-argcomplete3 colcon)"
+elif type register-python-argcomplete > /dev/null 2>&1; then
+  eval "$(register-python-argcomplete colcon)"
+fi

--- a/completion/colcon-argcomplete.zsh
+++ b/completion/colcon-argcomplete.zsh
@@ -1,3 +1,7 @@
 autoload -U +X compinit && compinit
 autoload -U +X bashcompinit && bashcompinit
-eval "$(register-python-argcomplete colcon)"
+if type register-python-argcomplete3 > /dev/null 2>&1; then
+  eval "$(register-python-argcomplete3 colcon)"
+elif type register-python-argcomplete > /dev/null 2>&1; then
+  eval "$(register-python-argcomplete colcon)"
+fi


### PR DESCRIPTION
Call `register-python-argcomplete3` when available which is the case when `argcomplete` is installed using the Debian package `python3-argcomplete`. Otherwise try the version without the version suffix.