### PR TITLE
fix completion for partial input

### DIFF
--- a/colcon_argcomplete/argument_parser/argcomplete/__init__.py
+++ b/colcon_argcomplete/argument_parser/argcomplete/__init__.py
@@ -1,7 +1,9 @@
 # Copyright 2016-2018 Dirk Thomas
 # Licensed under the Apache License, Version 2.0
 
+import argparse
 import os
+import shlex
 import time
 
 from colcon_argcomplete.argcomplete_completer import get_argcomplete_completer
@@ -68,8 +70,12 @@ class ArgcompleteDecorator(ArgumentParserDecorator):
     def parse_known_args(self, *args, **kwargs):
         """Override the args in completion mode."""
         if os.environ.get('_ARGCOMPLETE') == '1':
-            kwargs['args'] = os.environ['COMP_LINE'].split(' ')[1:]
-        return self._parser.parse_known_args(*args, **kwargs)
+            kwargs['args'] = shlex.split(os.environ['COMP_LINE'])[1:]
+        try:
+            return self._parser.parse_known_args(*args, **kwargs)
+        except SystemExit:
+            # if the partial arguments can't be parsed return no known args
+            return argparse.Namespace(verb_name=None), []
 
     def parse_args(self, *args, **kwargs):
         """Register argcomplete hook."""


### PR DESCRIPTION
Fix regression introduced in #11.

When trying to complete a partial command like `colcon ext<tab>` the `parse_known_args` function fails to parse the partial argument which results in a `SystemExit` being raised. That will break the completion.

This patch catches the exception and simply returns no known arguments in that case so the completion can continue.

Using `shlex` to split the `COMP_LINE` is an unrelated improvement.