### PR TITLE
add MANIFEST.in for the completion scripts

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include completion/colcon-argcomplete.*


### PR DESCRIPTION
Aims to fix #14 by using a `MANIFEST.in` file to include the completion scripts in the `sdist`.