### PR TITLE
Revert "add MANIFEST.in for the completion scripts (#18)"

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,0 @@
-include completion/colcon-argcomplete.*


### PR DESCRIPTION
Reverts colcon/colcon-argcomplete#18.

Fixes #19 but reopens #14.

While the patch allowed to release the package without creating the wheel it fails for the user since `pip` will try to create a wheel on the user machine on the fly, see https://packaging.python.org/tutorials/installing-packages/#source-distributions-vs-wheels:

> If pip does not find a wheel to install, it will locally build a wheel and cache it for future installs, instead of rebuilding the source distribution in the future.