### PR TITLE
declare hooks as data_files in setup.cfg

### DIFF
--- a/colcon.pkg
+++ b/colcon.pkg
@@ -1,6 +1,6 @@
 {
     "hooks": [
-        "share/colcon-argcomplete/hook/colcon-argcomplete.bash",
-        "share/colcon-argcomplete/hook/colcon-argcomplete.zsh"
+        "share/colcon_argcomplete/hook/colcon-argcomplete.bash",
+        "share/colcon_argcomplete/hook/colcon-argcomplete.zsh"
     ]
 }

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,12 @@ tests_require =
   pytest-cov
 zip_safe = false
 
+[options.data_files]
+# distutils replaces dashes in keys with underscores
+share/colcon_argcomplete/hook =
+    completion/colcon-argcomplete.bash
+    completion/colcon-argcomplete.zsh
+
 [tool:pytest]
 filterwarnings =
     error

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,11 @@
 # Copyright 2016-2018 Dirk Thomas
 # Licensed under the Apache License, Version 2.0
 
-import distutils.command.install as distutils_install
-import inspect
-import os
-import shutil
 import sys
 
+from pkg_resources import parse_version
+from setuptools import __version__ as setuptools_version
 from setuptools import setup
-from setuptools.command.develop import develop
-from setuptools.command.install import install
-
 
 if sys.platform == 'win32':
     print(
@@ -18,135 +13,12 @@ if sys.platform == 'win32':
         file=sys.stderr)
     sys.exit(1)
 
-src_base = 'completion'
-data_files = (
-    ('share/colcon-argcomplete/hook', [
-        'completion/colcon-argcomplete.bash',
-        'completion/colcon-argcomplete.zsh']),
-)
+setuptools_min_version = '40.5.0'
+if parse_version(setuptools_version) < parse_version(setuptools_min_version):
+    print(
+        "The Python package 'colcon-argcomplete' requires at least setuptools "
+        'version {setuptools_min_version}'.format_map(locals()),
+        file=sys.stderr)
+    sys.exit(1)
 
-src_base_offset = None
-dst_prefix = None
-if not os.path.exists(src_base):
-    # assuming this is a deb_dist build
-    if os.path.exists(os.path.join('..', '..', src_base)):
-        # use source base offset for data files
-        for _, srcs in data_files:
-            for i, src in enumerate(srcs):
-                srcs[i] = os.path.join('..', '..', src)
-        # use dst prefix for data files
-        dst_prefix = os.path.join(
-            os.getcwd(), 'debian/python3-colcon-argcomplete')
-
-
-# in order to be referenced from the colcon.pkg file
-# the data files need to be installed into a known fixed location
-# which doesn't depend on the Python interpreter version and layout
-# therefore package_data can't be used and this chunk of code is necessary
-class CustomDevelopCommand(develop):
-
-    def install_for_development(self):
-        global data_files
-        super().install_for_development()
-
-        if sys.platform != 'win32':
-            _foreach_data_file(
-                self, data_files,
-                'Creating {dst_dir} (link to {src})',
-                _link_data_file)
-        else:
-            _foreach_data_file(
-                self, data_files,
-                'Copying {src} to {dst_dir}',
-                _copy_data_file)
-
-    def uninstall_link(self):
-        global data_files
-        super().uninstall_link()
-
-        _foreach_data_file(
-            self, data_files,
-            'Removing {dst}',
-            _remove_data_file)
-
-
-class CustomInstallCommand(install):
-
-    def run(self):
-        global data_files
-        # https://github.com/pypa/setuptools/blob/52aacd5b276fedd6849c3a648a0014f5da563e93/setuptools/command/install.py#L59-L67
-        # Explicit request for old-style install?  Just do it
-        if self.old_and_unmanageable or self.single_version_externally_managed:
-            distutils_install.install.run(self)
-        elif not self._called_from_setup(inspect.currentframe()):
-            # Run in backward-compatibility mode to support bdist_* commands.
-            distutils_install.install.run(self)
-        else:
-            super().do_egg_install()
-
-        _foreach_data_file(
-            self, data_files,
-            'Copying {src} to {dst_dir}',
-            _copy_data_file)
-
-
-def _foreach_data_file(command, data_files, msg, callback):
-    global dst_prefix
-    for dst_dir, srcs in data_files:
-        if command.prefix is not None:
-            dst_dir = os.path.join(command.prefix, dst_dir)
-        if dst_prefix:
-            dst_dir = os.path.join(dst_prefix) + dst_dir
-        for src in srcs:
-            dst = os.path.join(dst_dir, os.path.basename(src))
-            try:
-                src = os.path.join(
-                    os.path.dirname(os.path.realpath('setup.py')),
-                    src)
-            except OSError:
-                pass
-            print(msg.format_map(locals()))
-            if not command.dry_run:
-                callback(src, dst_dir, dst)
-
-
-def _copy_data_file(src, dst_dir, dst):
-    _prepare_destination(src, dst_dir, dst)
-    shutil.copy2(src, dst_dir)
-
-
-def _link_data_file(src, dst_dir, dst):
-    _prepare_destination(src, dst_dir, dst)
-    os.symlink(src, dst)
-
-
-def _prepare_destination(src, dst_dir, dst):
-    assert os.path.isfile(src), \
-        "data file '{src}' not found".format_map(locals())
-    assert os.path.isabs(dst_dir), \
-        'Install command needs to be invoked with --prefix ' \
-        'or the data files destination must be absolute'
-    assert not os.path.isfile(dst_dir), \
-        'data file destination directory must not be a file'
-    if not os.path.isdir(dst_dir):
-        os.makedirs(dst_dir, exist_ok=True)
-    try:
-        os.remove(dst)
-    except FileNotFoundError:
-        pass
-
-
-def _remove_data_file(src, dst_dir, dst):
-    assert os.path.isabs(dst)
-    try:
-        os.remove(dst)
-    except FileNotFoundError:
-        pass
-
-
-setup(
-    cmdclass={
-        'develop': CustomDevelopCommand,
-        'install': CustomInstallCommand,
-    },
-)
+setup()


### PR DESCRIPTION
The patch relies on a very recent feature added to setuptools 40.5.0 (see pypa/setuptools # 1520).

It should address #14 without introducing #19.

The renaming of the destination from `share/colcon-argcomplete` to `share/colcon_argcomplete` is unfortunately necessary since `distutils` on the very lowest level replaces `-` in keys with `_` (https://github.com/python/cpython/blob/31ec52a9afedd77e36a3ddc31c4c45664b8ac410/Lib/distutils/dist.py#L414) so it is impossible to install files to a destination containing dashes. Another downside is that the files are not symlinked anymore when using `develop`.