### PR TITLE
update setup file to use Debian specific approach for data_files

### DIFF
--- a/debian/patches/setup.cfg.patch
+++ b/debian/patches/setup.cfg.patch
@@ -1,0 +1,27 @@
+Description: Remove the data_files from the setup.cfg file since the
+ Debian package can't rely on setuptools 40.5.0 or higher.
+ Instead the custom logic in setup.py will handle these file for the
+ Debianpackage.
+ The custom logic doesn't work for a wheel though and therefore can't be
+ used generically.
+Author: Dirk Thomas <web@dirk-thomas.net>
+
+--- setup.cfg	2019-01-04 11:11:11.000000000 -0800
++++ setup.cfg.patched	2019-01-04 11:11:11.000000000 -0800
+@@ -45,10 +45,12 @@
+ 	pytest-cov
+ zip_safe = false
+ 
+-[options.data_files]
+-share/colcon_argcomplete/hook = 
+-	completion/colcon-argcomplete.bash
+-	completion/colcon-argcomplete.zsh
++# the Debian package can't rely on a recent setuptools version
++# which is necessary to support this option
++# [options.data_files]
++# share/colcon_argcomplete/hook = 
++# 	completion/colcon-argcomplete.bash
++# 	completion/colcon-argcomplete.zsh
+ 
+ [tool:pytest]
+ filterwarnings = 

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,9 @@
 # Copyright 2016-2018 Dirk Thomas
 # Licensed under the Apache License, Version 2.0
 
+import os
 import sys
 
-from pkg_resources import parse_version
-from setuptools import __version__ as setuptools_version
 from setuptools import setup
 
 if sys.platform == 'win32':
@@ -13,12 +12,145 @@ if sys.platform == 'win32':
         file=sys.stderr)
     sys.exit(1)
 
-setuptools_min_version = '40.5.0'
-if parse_version(setuptools_version) < parse_version(setuptools_min_version):
-    print(
-        "The Python package 'colcon-argcomplete' requires at least setuptools "
-        'version {setuptools_min_version}'.format_map(locals()),
-        file=sys.stderr)
-    sys.exit(1)
+if 'BUILD_DEBIAN_PACKAGE' not in os.environ:
+    from pkg_resources import parse_version
+    from setuptools import __version__ as setuptools_version
+    minimum_version = '40.5.0'
+    if parse_version(setuptools_version) < parse_version(minimum_version):
+        print(
+            "The Python package 'colcon-argcomplete' requires at least "
+            'setuptools version {minimum_version}'.format_map(locals()),
+            file=sys.stderr)
+        sys.exit(1)
 
-setup()
+cmdclass = {}
+try:
+    from stdeb.command.sdist_dsc import sdist_dsc
+except ImportError:
+    pass
+else:
+    class CustomSdistDebCommand(sdist_dsc):
+        """Weird approach to apply the Debian patches during packaging."""
+
+        def run(self):  # noqa: D102
+            from stdeb.command import sdist_dsc
+            build_dsc = sdist_dsc.build_dsc
+
+            def custom_build_dsc(*args, **kwargs):
+                nonlocal build_dsc
+                debinfo = self.get_debinfo()
+                repackaged_dirname = \
+                    debinfo.source + '-' + debinfo.upstream_version
+                dst_directory = os.path.join(
+                    self.dist_dir, repackaged_dirname, 'debian', 'patches')
+                os.makedirs(dst_directory, exist_ok=True)
+                # read patch
+                with open('debian/patches/setup.cfg.patch', 'r') as h:
+                    lines = h.read().splitlines()
+                print(
+                    "writing customized patch '%s'" %
+                    os.path.join(dst_directory, 'setup.cfg.patch'))
+                # write patch with modified path
+                with open(
+                    os.path.join(dst_directory, 'setup.cfg.patch'), 'w'
+                ) as h:
+                    for line in lines:
+                        if line.startswith('--- ') or line.startswith('+++ '):
+                            line = \
+                                line[0:4] + repackaged_dirname + '/' + line[4:]
+                        h.write(line + '\n')
+                with open(os.path.join(dst_directory, 'series'), 'w') as h:
+                    h.write('setup.cfg.patch\n')
+                return build_dsc(*args, **kwargs)
+
+            sdist_dsc.build_dsc = custom_build_dsc
+            super().run()
+    cmdclass['sdist_dsc'] = CustomSdistDebCommand
+
+if 'BUILD_DEBIAN_PACKAGE' in os.environ:
+    import distutils.command.install as distutils_install
+    import inspect
+    import shutil
+
+    from setuptools.command.install import install
+
+    src_base = 'completion'
+    data_files = (
+        ('share/colcon_argcomplete/hook', [
+            'completion/colcon-argcomplete.bash',
+            'completion/colcon-argcomplete.zsh']),
+    )
+
+    src_base_offset = None
+    dst_prefix = None
+    if not os.path.exists(src_base):
+        # assuming this is a deb_dist build
+        if os.path.exists(os.path.join('..', '..', src_base)):
+            # use source base offset for data files
+            for _, srcs in data_files:
+                for i, src in enumerate(srcs):
+                    srcs[i] = os.path.join('..', '..', src)
+            # use dst prefix for data files
+            dst_prefix = os.path.join(
+                os.getcwd(), 'debian/python3-colcon-argcomplete')
+
+    class CustomInstallCommand(install):
+
+        def run(self):
+            global data_files
+            # https://github.com/pypa/setuptools/blob/52aacd5b276fedd6849c3a648a0014f5da563e93/setuptools/command/install.py#L59-L67
+            # Explicit request for old-style install?  Just do it
+            if self.old_and_unmanageable or self.single_version_externally_managed:
+                distutils_install.install.run(self)
+            elif not self._called_from_setup(inspect.currentframe()):
+                # Run in backward-compatibility mode to support bdist_* commands.
+                distutils_install.install.run(self)
+            else:
+                super().do_egg_install()
+
+            _foreach_data_file(
+                self, data_files,
+                'Copying {src} to {dst_dir}',
+                _copy_data_file)
+
+    def _foreach_data_file(command, data_files, msg, callback):
+        global dst_prefix
+        for dst_dir, srcs in data_files:
+            if command.prefix is not None:
+                dst_dir = os.path.join(command.prefix, dst_dir)
+            if dst_prefix:
+                dst_dir = os.path.join(dst_prefix) + dst_dir
+            for src in srcs:
+                dst = os.path.join(dst_dir, os.path.basename(src))
+                try:
+                    src = os.path.join(
+                        os.path.dirname(os.path.realpath('setup.py')),
+                        src)
+                except OSError:
+                    pass
+                print(msg.format_map(locals()))
+                if not command.dry_run:
+                    callback(src, dst_dir, dst)
+
+    def _copy_data_file(src, dst_dir, dst):
+        _prepare_destination(src, dst_dir, dst)
+        shutil.copy2(src, dst_dir)
+
+    def _prepare_destination(src, dst_dir, dst):
+        assert os.path.isfile(src), \
+            "data file '{src}' not found".format_map(locals())
+        assert os.path.isabs(dst_dir), \
+            'Install command needs to be invoked with --prefix ' \
+            'or the data files destination must be absolute'
+        assert not os.path.isfile(dst_dir), \
+            'data file destination directory must not be a file'
+        if not os.path.isdir(dst_dir):
+            os.makedirs(dst_dir, exist_ok=True)
+        try:
+            os.remove(dst)
+        except FileNotFoundError:
+            pass
+
+        cmdclass['install'] = CustomInstallCommand
+
+setup(cmdclass=cmdclass)

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -2,3 +2,4 @@
 Depends3: python3-argcomplete, python3-colcon-core
 Suite: xenial bionic stretch buster
 X-Python3-Version: >= 3.5
+Setup-Env-Vars: BUILD_DEBIAN_PACKAGE=1


### PR DESCRIPTION
Follow up of #21 to make the Debian release still use the custom `cmdclass` since it can't rely on a recent setuptools version.