### PR TITLE
Use --root specified on command line when running custom install command

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,8 +81,6 @@ if 'BUILD_DEBIAN_PACKAGE' in os.environ:
             'completion/colcon-argcomplete.zsh']),
     )
 
-    src_base_offset = None
-    dst_prefix = None
     if not os.path.exists(src_base):
         # assuming this is a deb_dist build
         if os.path.exists(os.path.join('..', '..', src_base)):
@@ -90,9 +88,6 @@ if 'BUILD_DEBIAN_PACKAGE' in os.environ:
             for _, srcs in data_files:
                 for i, src in enumerate(srcs):
                     srcs[i] = os.path.join('..', '..', src)
-            # use dst prefix for data files
-            dst_prefix = os.path.join(
-                os.getcwd(), 'debian/python3-colcon-argcomplete')
 
     class CustomInstallCommand(install):
 
@@ -114,12 +109,11 @@ if 'BUILD_DEBIAN_PACKAGE' in os.environ:
                 _copy_data_file)
 
     def _foreach_data_file(command, data_files, msg, callback):
-        global dst_prefix
         for dst_dir, srcs in data_files:
             if command.prefix is not None:
                 dst_dir = os.path.join(command.prefix, dst_dir)
-            if dst_prefix:
-                dst_dir = os.path.join(dst_prefix) + dst_dir
+            if command.root is not None:
+                dst_dir = os.path.join(command.root) + dst_dir
             for src in srcs:
                 dst = os.path.join(dst_dir, os.path.basename(src))
                 try:


### PR DESCRIPTION
Instead of hand-crafting the destination path, use the `--root` arg passed to `setup.py install` by debhelper.

Fedora runs the install from the package root directory, so re-rooting the source paths isn't necessary, but the `--root` arg must be considered for the destination path.