### PR TITLE
Fix custom install of completion files during deb build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -151,6 +151,6 @@ if 'BUILD_DEBIAN_PACKAGE' in os.environ:
         except FileNotFoundError:
             pass
 
-        cmdclass['install'] = CustomInstallCommand
+    cmdclass['install'] = CustomInstallCommand
 
 setup(cmdclass=cmdclass)


### PR DESCRIPTION
I think this was just a little bug introduced by the most recent release.