### PR TITLE
fix condition to use dst_prefix during deb_dist

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,18 +81,12 @@ if 'BUILD_DEBIAN_PACKAGE' in os.environ:
             'completion/colcon-argcomplete.zsh']),
     )
 
-    src_base_offset = None
     dst_prefix = None
-    if not os.path.exists(src_base):
+    if os.path.exists('.pc/applied-patches'):
         # assuming this is a deb_dist build
-        if os.path.exists(os.path.join('..', '..', src_base)):
-            # use source base offset for data files
-            for _, srcs in data_files:
-                for i, src in enumerate(srcs):
-                    srcs[i] = os.path.join('..', '..', src)
-            # use dst prefix for data files
-            dst_prefix = os.path.join(
-                os.getcwd(), 'debian/python3-colcon-argcomplete')
+        # use dst prefix for data files
+        dst_prefix = os.path.join(
+            os.getcwd(), 'debian/python3-colcon-argcomplete')
 
     class CustomInstallCommand(install):
 


### PR DESCRIPTION
Follow up of #24.

The condition `if not os.path.exists(src_base):` was never `True` and therefore the `dst_prefix` was never used which resulted in the hooks to be installed into `/usr/...` instead of the local `deb_dist` directory.

With the updated condition `ros_release_python deb3` doesn't try to write to `/usr/...` anymore and the hooks are part of the Debian package.