### PR TITLE
better handle set but empty environment variable

### DIFF
--- a/colcon_argcomplete/argument_parser/argcomplete/__init__.py
+++ b/colcon_argcomplete/argument_parser/argcomplete/__init__.py
@@ -86,7 +86,7 @@ class ArgcompleteDecorator(ArgumentParserDecorator):
 
         # if requested log the duration the completion took into a file
         logfile = os.environ.get(COMPLETION_LOGFILE_ENVIRONMENT_VARIABLE.name)
-        if _is_completion_requested() and logfile is not None:
+        if _is_completion_requested() and logfile:
             duration = time.monotonic() - _start_time
             comp_line = os.environ['COMP_LINE']
             with open(logfile, 'a') as h:


### PR DESCRIPTION
Since the environment variable needs to specify a path using an empty value doesn't make sense. Instead consider an empty value to be the same as an unset environment variable.