### PR TITLE
ZSH argcomplete: call compinit only if needed

### DIFF
--- a/completion/colcon-argcomplete.zsh
+++ b/completion/colcon-argcomplete.zsh
@@ -1,4 +1,6 @@
-autoload -U +X compinit && compinit
+if (( ! ${+_comps} )); then
+  autoload -U +X compinit && compinit
+fi
 autoload -U +X bashcompinit && bashcompinit
 if type register-python-argcomplete3 > /dev/null 2>&1; then
   eval "$(register-python-argcomplete3 colcon)"


### PR DESCRIPTION
Ref https://github.com/ros2/ros2cli/issues/534#issuecomment-1173901509
As stated in the comment above, I'm not sure if this is the most correct solution... but it should help a bit.